### PR TITLE
fix: changed from Strings to using the type system

### DIFF
--- a/src/angle.rs
+++ b/src/angle.rs
@@ -1,9 +1,10 @@
 use crate::Unit;
 use core::f64::consts::PI;
 
-create_unit_type!(Radians, 1.0, String::from("Angle"));
-create_unit_type!(Degrees, 180.0 / PI, String::from("Angle"));
-create_unit_type!(Rotations, 1.0 / (PI * 2.0), String::from("Angle"));
+pub enum Angle {}
+create_unit_type!(Radians, 1.0, Angle);
+create_unit_type!(Degrees, 180.0 / PI, Angle);
+create_unit_type!(Rotations, 1.0 / (PI * 2.0), Angle);
 
 #[cfg(test)]
 mod tests {

--- a/src/length.rs
+++ b/src/length.rs
@@ -1,10 +1,11 @@
 use crate::Unit;
 
-create_unit_type!(Kilometres, 0.001, String::from("Length"));
-create_unit_type!(Metres, 1.0, String::from("Length"));
-create_unit_type!(Decimetres, 10.0, String::from("Length"));
-create_unit_type!(Centimetres, 100.0, String::from("Length"));
-create_unit_type!(Millimetres, 1000.0, String::from("Length"));
+pub enum Length{}
+create_unit_type!(Kilometres, 0.001, Length);
+create_unit_type!(Metres, 1.0, Length);
+create_unit_type!(Decimetres, 10.0, Length);
+create_unit_type!(Centimetres, 100.0, Length);
+create_unit_type!(Millimetres, 1000.0, Length);
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,11 @@
 /// The Unit trait for creating all unit types from.
-pub trait Unit {
+pub trait Unit<U> {
     /// The conversion factor to the SI unit.
     fn conversion_factor() -> f64;
-    /// The type of the unit eg, Length, Angle.
-    fn get_type() -> String;
     /// Returns the value of the unit as the SI value.
     fn get_as_si(&self) -> f64;
     /// Converts the unit to the specified Unit. Panics if the types are not the same.
-    fn convert<T: Unit>(&self) -> T {
-        assert_eq!(Self::get_type(), T::get_type());
+    fn convert<T: Unit<U>>(&self) -> T {
         T::new(self.get_as_si() * T::conversion_factor())
     }
     /// Creates a new instance of the Unit.
@@ -19,18 +16,14 @@ pub trait Unit {
 /// Creates the specified Unit type. Takes in the name, conversion factor (a f64) and the type (a
 /// String)
 macro_rules! create_unit_type {
-    ($name:ident, $conversion_factor:expr, $type:expr) => {
+    ($name:ident, $conversion_factor:expr, $type:ty) => {
         pub struct $name {
             value: f64,
         }
 
-        impl Unit for $name {
+        impl Unit<$type> for $name {
             fn conversion_factor() -> f64 {
                 $conversion_factor
-            }
-
-            fn get_type() -> String {
-                $type
             }
 
             fn get_as_si(&self) -> f64 {


### PR DESCRIPTION
- Now uses the type system and zero sized types to achieve compile-time unit type compatibility
- No longer offloads this work onto the runtime
- Continues to allow users to extend and implement their own types
- api is exactly the same, expect type is no longer remembered at runtime

additional notes:
- I recently implemented a very similar system in Kotlin, in a not quite so nice way, but with enough manual labour I managed to get it to work.
- remember to leverage the strength of the type system to your advantage!
- You should implement optimisations so that when a conversion happens from a type to the same time (i.e. meter to meter) this is a no-op